### PR TITLE
Iterate-AI added 3 events

### DIFF
--- a/frontend/src/Components/Browse.jsx
+++ b/frontend/src/Components/Browse.jsx
@@ -35,9 +35,7 @@ function Browse() {
   return Dark ? JSON.parse(Dark) : true
  })
  const user = useSelector(state => state.user.user)
- useEffect(() => {
-  window.scrollTo(0, 0)
- }, [])
+ useEffect(() => { window.scrollTo(0, 0); mixpanel.track('home page opened', {'categories shown': Tags.join(', ')}); }, [Tags])
  useEffect(() => {
   const handleMenuButtonClick = () => {
    setMenuClicked(prevMenuClicked => !prevMenuClicked)
@@ -160,13 +158,7 @@ function Browse() {
        {Tags.map((element, index) => {
         return (
          <div className={TagsSelected === element ? `top-tags ${theme ? 'tag-color' : 'tag-color-light'}` : `top-tags ${theme ? '' : 'tagcolor-newlight'}`} key={index}>
-          <p
-           onClick={() => {
-            setTagsSelected(`${element}`)
-           }}
-          >
-           {element}
-          </p>
+          <p onClick={(e) => { setTagsSelected(e.target.textContent); mixpanel.track('category selected', {'category name': e.target.textContent}); }}> {element} </p>
          </div>
         )
        })}
@@ -256,13 +248,7 @@ function Browse() {
       {Tags.map((element, index) => {
        return (
         <div className={TagsSelected === element ? `top-tags ${theme ? 'tag-color' : 'tag-color-light'}` : `top-tags ${theme ? '' : 'tagcolor-newlight'}`} key={index}>
-         <p
-          onClick={() => {
-           setTagsSelected(element)
-          }}
-         >
-          {element}
-         </p>
+         <p onClick={(e) => { setTagsSelected(e.target.textContent); mixpanel.track('category selected', {'category name': e.target.textContent}); }}> {element} </p>
         </div>
        )
       })}
@@ -304,16 +290,7 @@ function Browse() {
                 display: 'none'
                }
            }
-           onClick={() => {
-            if (user?.success) {
-             updateViews(VideoID[index])
-             setTimeout(() => {
-              navigate(`/video/${VideoID[index]}`)
-             }, 400)
-            }
-            navigate(`/video/${VideoID[index]}`)
-            mixpanel.track('video_clicked', {selected_video_title: Titles[index]})
-           }}
+           onClick={() => { if (user?.success) { updateViews(VideoID[index]) setTimeout(() => { navigate(`/video/${VideoID[index]}`) }, 400) } navigate(`/video/${VideoID[index]}`) mixpanel.track('video clicked', { category: TagsSelected, title: Titles[index], publisher: uploader[index], view_count: VideoViews[index], length_in_seconds: duration[index] }) }}
           >
            <img
             style={{


### PR DESCRIPTION

        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/src/Components/Browse.jsx
        Event Name: category selected
        Attributes: category name (String)
        Description: This change adds tracking for the event "category selected" 
        with the following attributes: category name: name of the category selected (e.g., Artificial Intelligence)
        
        
        
        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/src/Components/Browse.jsx
        Event Name: video clicked
        Attributes: category (String), title (String), publisher (String), view count (Numeric), length in seconds (Numeric)
        Description: This change adds tracking for the event "video clicked" 
        with the following attributes: category: category of the video (e.g., Artificial Intelligence), title: Title of the video clicked by the user (e.g., How I make killer thumbnails using ChatGPT vision), publisher: name of the publisher of the video (e.g., Rohit Singh), view count: number of views on the video (e.g., 576500), length in seconds: time length of the video in seconds (e.g., 300)
        
        
        
        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/src/Components/Browse.jsx
        Event Name: home page opened
        Attributes: categories shown (List)
        Description: This change adds tracking for the event "home page opened" 
        with the following attributes: categories shown: categories shown on the home page (e.g., ["Artificial Intelligence","Comedy","Gaming","Vlog","Beauty","Travel","Food","Fashion"])
        
        
        