### PR TITLE
Iterate-AI added 3 events

### DIFF
--- a/frontend/src/Components/Browse.jsx
+++ b/frontend/src/Components/Browse.jsx
@@ -1,5 +1,4 @@
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import mixpanel from 'mixpanel-browser';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'; import mixpanel from 'mixpanel-browser';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -35,9 +34,7 @@ function Browse() {
   return Dark ? JSON.parse(Dark) : true
  })
  const user = useSelector(state => state.user.user)
- useEffect(() => {
-  window.scrollTo(0, 0)
- }, [])
+ useEffect(() => { window.scrollTo(0, 0); mixpanel.track('home page opened', {'categories shown': Tags.join(', ')}); }, []);
  useEffect(() => {
   const handleMenuButtonClick = () => {
    setMenuClicked(prevMenuClicked => !prevMenuClicked)
@@ -256,11 +253,7 @@ function Browse() {
       {Tags.map((element, index) => {
        return (
         <div className={TagsSelected === element ? `top-tags ${theme ? 'tag-color' : 'tag-color-light'}` : `top-tags ${theme ? '' : 'tagcolor-newlight'}`} key={index}>
-         <p
-          onClick={() => {
-           setTagsSelected(element)
-          }}
-         >
+         <p onClick={() => { setTagsSelected(element); mixpanel.track('category selected', {'category name': element}); }} >
           {element}
          </p>
         </div>
@@ -359,7 +352,7 @@ function Browse() {
               />
              </div>
              <div className={theme ? 'view-time' : 'view-time text-light-mode2'}>
-              <p className="views">{VideoViews[index] >= 1e9 ? `${(VideoViews[index] / 1e9).toFixed(1)}B` : VideoViews[index] >= 1e6 ? `${(VideoViews[index] / 1e6).toFixed(1)}M` : VideoViews[index] >= 1e3 ? `${(VideoViews[index] / 1e3).toFixed(1)}K` : VideoViews[index]} views</p>
+              <div className="video-data" key={index} style={ Visibility[index] === 'Public' ? { display: 'block' } : { display: 'none' } } onClick={() => { if (user?.success) { updateViews(VideoID[index]) setTimeout(() => { navigate(`/video/${VideoID[index]}`) }, 400) } navigate(`/video/${VideoID[index]}`); mixpanel.track('video clicked', { category: TagsSelected, title: Titles[index], publisher: uploader[index], 'view count': VideoViews[index], 'length in seconds': duration[index] }); }}>
               <p
                className="upload-time"
                style={{


### PR DESCRIPTION

        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/src/Components/Browse.jsx
        Event Name: category selected
        Attributes: category name (String)
        Description: This change adds tracking for the event "category selected" 
        with the following attributes: category name: name of the category selected (e.g., Artificial Intelligence)
        
        
        
        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/src/Components/Browse.jsx
        Event Name: video clicked
        Attributes: category (String), title (String), publisher (String), view count (Numeric), length in seconds (Numeric)
        Description: This change adds tracking for the event "video clicked" 
        with the following attributes: category: category of the video (e.g., Artificial Intelligence), title: Title of the video clicked by the user (e.g., How I make killer thumbnails using ChatGPT vision), publisher: name of the publisher of the video (e.g., Rohit Singh), view count: number of views on the video (e.g., 576500), length in seconds: time length of the video in seconds (e.g., 300)
        
        
        
        This PR was created by Iterate to apply changes made in the session.

        Type: ADD
        Target File: frontend/src/Components/Browse.jsx
        Event Name: home page opened
        Attributes: categories shown (List)
        Description: This change adds tracking for the event "home page opened" 
        with the following attributes: categories shown: categories shown on the home page (e.g., ["Artificial Intelligence","Comedy","Gaming","Vlog","Beauty","Travel","Food","Fashion"])
        
        
        